### PR TITLE
序列化all字符串错误

### DIFF
--- a/backend/apps/lunarlink/serializers.py
+++ b/backend/apps/lunarlink/serializers.py
@@ -118,7 +118,7 @@ class RelationSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = models.Relation
-        fields = "__all_"
+        fields = "__all__"
 
 
 class AssertSerializer(serializers.Serializer):


### PR DESCRIPTION
`fields = "__all_"`** 在 `RelationSerializer` 中，`fields` 的值应该是 `"__all__"` 而不是 `"__all_"`。这是一个拼写错误，会导致序列化器无法正常工作